### PR TITLE
manifest: 6.0.1_r30

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -19,7 +19,7 @@
            review="gerrit.twrp.me"
            fetch="https://github.com/TeamWin" />
 
-  <default revision="refs/tags/android-6.0.1_r24"
+  <default revision="refs/tags/android-6.0.1_r30"
            remote="aosp"
            sync-c="true"
            sync-j="4" />


### PR DESCRIPTION
OmniROM has updated it's code to 6.0.1_r30, so we should update as well. If you take a look at this commit: https://github.com/omnirom/android/commit/1d8052c29b2e678887edd089aadf2aa91f10b0ad, you can see that OmniROM has updated.