### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ let me fix it because I was found out!" message.
 ---------------
 
 To get started with OMNI ROM, you'll need to get
-familiar with [Git and Repo](http://source.android.com/download/using-repo).
+familiar with [Git and Repo](https://source.android.com/source/using-repo.html).
 
 To initialize your local repository using the OMNIROM trees, use a command like this:
 


### PR DESCRIPTION
Fix typo in 'get familiar with [Git and Repo]' link.

Change-Id: I5f0a7b1a3d1f1cd57de288e9f1feeb2fcb1c19be